### PR TITLE
DD-1946: upgrade parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans</groupId>
         <artifactId>dd-parent</artifactId>
-        <version>1.9.1-SNAPSHOT</version>
+        <version>1.10.0</version>
     </parent>
 
     <artifactId>dd-validate-dans-bag-cli</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans</groupId>
         <artifactId>dd-parent</artifactId>
-        <version>1.9.0</version>
+        <version>1.9.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>dd-validate-dans-bag-cli</artifactId>
@@ -36,7 +36,6 @@
     <properties>
         <main-class>nl.knaw.dans.validatecli.DdValidateDansBagCli</main-class>
         <command-name>dans-bag-validate</command-name>
-        <dd-validate-dans-bag-api.version>1.0.0</dd-validate-dans-bag-api.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
Fixes DD-

# Description of changes


# How tested

Executed `start.sh -p=DEPOSIT /vagrant/shared/bag` (an empty dierctory)
with `v. 6.7.1 build DANS-DataStation-PATCH-7`
what resulted in `"rule":"1.2.1","violation":"bag-info.txt does not exist"`
With a bag copied from sword-examples I got an internal server error

    {"status":"error","message":"Endpoint restricted to localhost access only."}
    ...
    ! at nl.knaw.dans.validatedansbag.core.service.DataverseServiceImpl.getMaxEmbargoDurationInMonths(DataverseServiceImpl.java:94)
    ! at nl.knaw.dans.validatedansbag.core.rules.DatasetXmlEmbargoPeriodWithinLimits.validate(DatasetXmlEmbargoPeriodWithinLimits.java:38)
    ! at nl.knaw.dans.lib.util.ruleengine.RuleEngineImpl.validateBag(RuleEngineImpl.java:77)
    ....


An attempt deploying the cli did not make it available on the VM. 

It might not be related but the following settings were still active

       curl -X PUT -d s3kretKey http://localhost:8080/api/admin/settings/:BlockedApiKey
       curl -X PUT -d unblock-key http://localhost:8080/api/admin/settings/:BlockedApiPolicy

# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/core-systems
